### PR TITLE
provider-details: Replace 'Run privately' with 'Not run by a company'

### DIFF
--- a/themes/xmpp-providers/layouts/shortcodes/provider-details.html
+++ b/themes/xmpp-providers/layouts/shortcodes/provider-details.html
@@ -146,7 +146,7 @@
                         {{ if .company }}
                             Run by a company
                         {{ else }}
-                            Run privately
+                            Not run by a company
                         {{ end }}
                     </td>
                 </tr>


### PR DESCRIPTION
We tried to avoid negations for better readability. Thus, we decided to use *Run privately*. But that confused some visitors. As long as there is no [replacement for that property](https://invent.kde.org/melvo/xmpp-providers/-/issues/69) I suggest to use the negation in order to avoid confusion.